### PR TITLE
feat(version): add bump-version.sh and pre-push version guard

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Bump workspace version across all files that must stay in sync.
+#
+# Usage:
+#   ./scripts/bump-version.sh 0.7.0
+#
+# Updates:
+#   - Cargo.toml                  [workspace.package] version = "X.Y.Z"
+#   - skills/ahma/SKILL.md        version: X.Y.Z
+#   - scripts/install.sh          AHMA_VERSION="X.Y.Z"
+#   - scripts/install.ps1         version: X.Y.Z (YAML frontmatter)
+#   - scripts/install.ps1         <!-- version: X.Y.Z | ... --> (HTML comment)
+#   - scripts/install.ps1         Install-OneSkill -Version 'X.Y.Z'
+#
+# After updating, runs the version-consistency test to verify.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+NEW_VER="${1:-}"
+if [[ -z "$NEW_VER" ]]; then
+  echo "Usage: $0 <new-version>  (e.g. $0 0.7.0)"
+  exit 1
+fi
+
+# Validate semver format (X.Y.Z)
+if ! [[ "$NEW_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "FAIL Version '$NEW_VER' is not a valid semver (expected X.Y.Z)"
+  exit 1
+fi
+
+# Extract current version from Cargo.toml
+CUR_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+
+if [[ "$CUR_VER" == "$NEW_VER" ]]; then
+  echo "Already at version $NEW_VER — nothing to do."
+  exit 0
+fi
+
+echo "Bumping $CUR_VER → $NEW_VER"
+echo ""
+
+# Helper: in-place replace with perl (works on both macOS and Linux)
+replace() {
+  local pattern="$1"
+  local file="$2"
+  perl -i -pe "$pattern" "$file"
+}
+
+# 1. Cargo.toml: version = "X.Y.Z"
+replace "s|^(version = \")${CUR_VER}\"|\${1}${NEW_VER}\"|" Cargo.toml
+echo "  OK Cargo.toml"
+
+# 2. skills/ahma/SKILL.md: version: X.Y.Z
+replace "s|^(version: )${CUR_VER}|\${1}${NEW_VER}|" skills/ahma/SKILL.md
+echo "  OK skills/ahma/SKILL.md"
+
+# 3. scripts/install.sh: AHMA_VERSION="X.Y.Z"
+replace "s|^(AHMA_VERSION=\")${CUR_VER}\"|\${1}${NEW_VER}\"|" scripts/install.sh
+echo "  OK scripts/install.sh"
+
+# 4. scripts/install.ps1 — three patterns:
+#    a) YAML frontmatter line:  "    version: X.Y.Z"
+replace "s|(^\s+version: )${CUR_VER}|\${1}${NEW_VER}|" scripts/install.ps1
+#    b) HTML comment:           "<!-- version: X.Y.Z | ... -->"
+replace "s|(<!-- version: )${CUR_VER}( \|)|\${1}${NEW_VER}\${2}|" scripts/install.ps1
+#    c) Install-OneSkill call:  "Install-OneSkill -Name 'ahma' -Version 'X.Y.Z'"
+replace "s|(Install-OneSkill\b[^']*-Version ')${CUR_VER}'|\${1}${NEW_VER}'|" scripts/install.ps1
+echo "  OK scripts/install.ps1"
+
+echo ""
+echo "Verifying with nextest..."
+cargo nextest run -E 'test(skill_versions)'
+echo ""
+echo "Done. Version bumped to $NEW_VER."
+echo "Suggested commit:"
+echo "  git add Cargo.toml skills/ahma/SKILL.md scripts/install.sh scripts/install.ps1"
+echo "  git commit -m \"chore(release): bump version to $NEW_VER\""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -973,7 +973,7 @@ function Invoke-AhmaSkillSetup {
 
     Write-Host ""
     Write-Host "  Installing skills..."
-    Install-OneSkill -Name 'ahma' -Version '0.6.0' -ContentFn { Get-AhmaMainSkillContent }
+    Install-OneSkill -Name 'ahma' -Version '0.6.1' -ContentFn { Get-AhmaMainSkillContent }
 
     Write-Host ""
     Write-Host "  Skills are automatically available in:"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -25,6 +25,41 @@ if [ -n "$DIRTY_STATUS" ]; then
 fi
 
 echo "OK Working tree is clean"
+
+echo "=== Guardrail: version consistency ==="
+CARGO_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+INSTALL_VER=$(grep '^AHMA_VERSION=' scripts/install.sh | head -1 | sed 's/AHMA_VERSION="\(.*\)"/\1/')
+AHMA_SKILL_VER=$(grep '^version:' skills/ahma/SKILL.md | head -1 | awk '{print $2}')
+PS1_INSTALL_VERS=$(grep "Install-OneSkill.*-Version" scripts/install.ps1 | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | sort -u)
+
+VER_FAIL=0
+if [ "$INSTALL_VER" != "$CARGO_VER" ]; then
+  echo "FAIL scripts/install.sh AHMA_VERSION=\"${INSTALL_VER}\" != Cargo.toml \"${CARGO_VER}\""
+  VER_FAIL=1
+fi
+if [ "$AHMA_SKILL_VER" != "$CARGO_VER" ]; then
+  echo "FAIL skills/ahma/SKILL.md version: ${AHMA_SKILL_VER} != Cargo.toml ${CARGO_VER}"
+  VER_FAIL=1
+fi
+if [ -z "$PS1_INSTALL_VERS" ]; then
+  echo "FAIL scripts/install.ps1 has no Install-OneSkill -Version lines"
+  VER_FAIL=1
+else
+  while IFS= read -r ps1_ver; do
+    if [ "$ps1_ver" != "$CARGO_VER" ]; then
+      echo "FAIL scripts/install.ps1 Install-OneSkill version ${ps1_ver} != Cargo.toml ${CARGO_VER}"
+      VER_FAIL=1
+    fi
+  done <<< "$PS1_INSTALL_VERS"
+fi
+if [ "$VER_FAIL" -ne 0 ]; then
+  echo ""
+  echo "  Run: ./scripts/bump-version.sh ${CARGO_VER}"
+  echo "  to sync all version strings to the Cargo.toml value."
+  exit 1
+fi
+echo "OK Version strings consistent (v${CARGO_VER})"
+
 echo "=== Running cargo check --workspace --locked ==="
 cargo check --workspace --locked
 


### PR DESCRIPTION
Prevents version-drift CI failures from recurring (as seen in run #24649847667).

## Changes

### `scripts/bump-version.sh` (new)
One command to bump all version strings atomically:
- `Cargo.toml` — workspace version
- `skills/ahma/SKILL.md` — `version:` YAML field
- `scripts/install.sh` — `AHMA_VERSION=`
- `scripts/install.ps1` — YAML frontmatter, HTML comment, `Install-OneSkill -Version`

Runs `cargo nextest run -E 'test(skill_versions)'` after updating to verify.

**Usage:** `./scripts/bump-version.sh 0.7.0`

### `scripts/pre-push.sh` (updated)
Adds version consistency check before `cargo check`, so mismatches are caught locally before reaching CI. Shows exactly which file is out of sync and suggests the fix command.

### `scripts/install.ps1` (fix)
Fix missed `Install-OneSkill -Version '0.6.0'` → `'0.6.1'` (the nextest invariant test checked YAML-style `version:` lines but not this call site; `check-guardrails.sh` caught it).

## Verification
- 1923/1923 tests pass (`cargo nextest run --no-fail-fast`)