### PR TITLE
fix(ci): use versioned release tags instead of rolling 'latest'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -667,14 +667,33 @@ jobs:
           echo "SHA256SUMS contents:"
           cat SHA256SUMS
 
+      - name: Determine release tag
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed -E 's/^version = "(.*)"/\1/')
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          # Skip if this exact version was already published
+          if gh release view "${TAG}" --json tagName > /dev/null 2>&1; then
+            echo "already_released=true" >> "$GITHUB_OUTPUT"
+            echo "Release ${TAG} already exists — skipping."
+          else
+            echo "already_released=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
+        if: steps.version.outputs.already_released == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
-          name: Latest Release
-          body: "Automated release from main branch"
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body: "Release ${{ steps.version.outputs.tag }} from main branch"
           draft: false
           prerelease: false
+          make_latest: "true"
           files: |
             ahma-release-*.tar.gz
             ahma-release-*.zip

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -32,7 +32,7 @@ $installDir = if ($env:AHMA_INSTALL_DIR) {
 }
 
 # ── Fetch latest release metadata ─────────────────────────────────────────────
-$releasesUrl = "https://api.github.com/repos/paulirotta/ahma/releases/tags/latest"
+$releasesUrl = "https://api.github.com/repos/paulirotta/ahma/releases/latest"
 Write-Host "Fetching latest release info..."
 
 try {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -108,7 +108,7 @@ fetch_release_json() {
     if [ -n "$RELEASE_JSON" ]; then
         return
     fi
-    RELEASES_URL="https://api.github.com/repos/paulirotta/ahma/releases/tags/latest"
+    RELEASES_URL="https://api.github.com/repos/paulirotta/ahma/releases/latest"
     if command -v curl >/dev/null 2>&1; then
         RELEASE_JSON=$(curl -s "$RELEASES_URL")
     elif command -v wget >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

The `latest` git tag name is permanently blocked in this repo. The previous CI-published release was marked **immutable** by GitHub, and even after deleting that release, the `latest` tag name reservation persists:

- `git push origin latest --force` → _Cannot create ref due to creations being restricted_
- GitHub REST API `POST /git/refs` with `refs/tags/latest` → _422 Reference update failed_

## Fix

Switch from a rolling `latest` tag to proper semver tags derived from Cargo.toml:

1. **`build.yml`** — Extract `VERSION` from `Cargo.toml`, use `v${VERSION}` as the release tag. Added idempotency: if the tag already exists, skip publishing (safe reruns). Set `make_latest: "true"` so GitHub's built-in "latest release" API always points to the newest version.

2. **`install.sh` / `install.ps1`** — Change download URL from `/releases/tags/latest` to `/releases/latest` (GitHub's native endpoint for the most recent non-prerelease release). This works regardless of tag name.

## Testing

The `v0.6.1` tag does not yet exist, so merging this will immediately publish the `v0.6.1` release via the Publish Release CI job.